### PR TITLE
CLI tool[1]

### DIFF
--- a/task1/README.md
+++ b/task1/README.md
@@ -1,62 +1,36 @@
-# Домашнее задание №1  
-## CLI-инструмент для получения информации о репозитории GitHub
+# CLI tool for getting information about the GitHub repository
+
+A simple command-line tool written in **Go** that fetches and displays key information about a public GitHub repository using the official GitHub API.
 
 ---
 
-## Задача
+## Features
 
-Необходимо реализовать простой CLI-инструмент на Go, который получает информацию о репозитории GitHub и выводит её в консоль.
+- Fetches repository metadata by owner and name.
+- Displays:
+    - Repository Name
+    - Description
+    - Star Count
+    - Fork Count
+    - Creation Date
 
-Инструмент должен:
+## Prerequisites
 
-- принимать параметры репозитория (способ передачи --- на ваше усмотрение),
-- отправлять HTTP-запрос к GitHub,
-- получать JSON-ответ,
-- выводить ключевую информацию в читаемом виде.
+- [Go](https://go.dev/dl/) (version 1.20 or later recommended) installed on your machine.
 
-Репозиторий должен быть обязательно оформлен (хотя бы минимальный README с инструкцией к запуску).
+## Installation & Usage
 
----
+You don't need to install the binary globally. You can run the tool directly from the source code.
 
-## Минимальная информация, которую необходимо вывести
+### 1. Clone the repository
 
-1. Имя репозитория  
-2. Описание  
-3. Количество звёзд  
-4. Количество форков  
-5. Дата создания  
+```bash
+git clone <your-repository-url>
+cd <your-repository-directory>
+```
 
----
+### 2. Run the tool
 
-## Требования
-
-- Использовать только стандартную библиотеку Go.
-- Для сетевых запросов использовать `net/http`.
-- Выводить информацию в читаемом виде.
-- Обработать возможные ошибки:
-  - отсутствие репозитория,
-  - сетевые ошибки,
-  - некорректный ввод.
----
-
-## Формат сдачи задания
-
-Необходимо добавить ревьюеров в collaborators репозитория: `Settings -> Collaborators -> Add people`
-Ревьюеры:
-- https://github.com/suvorovrain
-- https://github.com/Dabzelos
-- https://github.com/vacmannnn
-
-Работу над заданием необходимо вести в отдельной ветке.
-
-В конце работы необходимо открыть PR из вашей ветки в main вашего форка и отметить ревьюеров в разделе `Reviewers`.
-
-В PR с выполненным заданием необходимо приложить скриншот работы приложения :).
-
-Рекоммендуется писать адекватное описание коммитов и PR.
-
-
-## Полезные материалы
-
-- Крутая книга для изучения GoLang: Jon Bodner --- Learning Go
-- Необходимая документация API GitHub для выполнения задания: https://docs.github.com/en/rest/repos
+```bash
+go run main.go -owner <OWNER> -repo <REPO_NAME>
+```

--- a/task1/go.mod
+++ b/task1/go.mod
@@ -1,0 +1,1 @@
+module task1

--- a/task1/main.go
+++ b/task1/main.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"time"
+)
+
+type RepoInfo struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Stars       int    `json:"stargazers_count"`
+	Forks       int    `json:"forks_count"`
+	CreatedAt   string `json:"created_at"`
+}
+
+func main() {
+
+	owner, repo := parseFlags()
+	result, err := fetchRepoInfo(owner, repo)
+	if err != nil {
+		log.Fatalf("Error: %v\n", err)
+	}
+	printInfo(result)
+}
+
+func parseFlags() (string, string) {
+	owner := flag.String("owner", "", "Owner name")
+	repo := flag.String("repo", "", "Repository name")
+	flag.Parse()
+
+	if *owner == "" || *repo == "" {
+		fmt.Println("Usage: go run main.go [-owner owner] [-repo repo]")
+		os.Exit(1)
+	}
+
+	return *owner, *repo
+}
+
+func fetchRepoInfo(owner, repo string) (*RepoInfo, error) {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/%s", owner, repo)
+	client := &http.Client{Timeout: 10 * time.Second}
+	response, err := client.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("network request failed: %w", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("repository not found or unavailable (%d)\n", response.StatusCode)
+	}
+
+	result := RepoInfo{}
+	if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &result, nil
+}
+
+func printInfo(result *RepoInfo) {
+	createdAt := makeDate(result.CreatedAt)
+
+	fmt.Printf(`--- Repository Information ---
+Name:          %s
+Description:   %s
+Stars:         %d
+Forks:         %d
+Created At:    %s
+`, result.Name, result.Description, result.Stars, result.Forks, createdAt)
+
+}
+
+func makeDate(raw string) string {
+	t, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return raw
+	}
+	return t.Format("Jan 02, 2006")
+}


### PR DESCRIPTION
## Summary
Implements a CLI tool to fetch and display GitHub repository metadata

### Screenshot
<img width="1115" height="206" alt="image" src="https://github.com/user-attachments/assets/cf680f4a-349a-43f6-900e-dbeda7c83c6a" />
